### PR TITLE
Make vibe.d dependency optional.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,9 +8,9 @@
        ,"Shamyan Roman (Zaramzan <shamyan.roman@gmail.com>)"
        ,"Denis Feklushkin <denis.feklushkin@gmail.com>"
        ],
-    "versions": ["VibeCustomMain", "Have_vibe_d", "Have_Int64_TimeStamp"],
+    "versions": ["Have_Int64_TimeStamp"],
     "dependencies": {
-        "vibe-d" : ">=0.7.21-beta.4",
+        "vibe-d" : { "version": ">=0.7.21-beta.4", "optional": true },
         "derelict-pq": ">=1.0.0",
         "dlogg": ">=0.3.3"
     },


### PR DESCRIPTION
I was having trouble getting this to work with a vibe.d application because of vibe.d needing to use it's own main function.  I had to make these changes to the package locally for it to compile without getting the error:
````
  "_main", referenced from:
     implicit entry/start for main executable
     (maybe you meant: _D4core6thread6Thread7sm_mainC4core6thread6Thread)
````

I made these adjustments based on what was done to the ddb (https://github.com/s-ludwig/ddb) library.  After reading the discussion here (http://forum.rejectedsoftware.com/groups/rejectedsoftware.vibed/thread/8346/) and looking at the PR here (https://github.com/s-ludwig/ddb/commit/52f348fc36ecacf6f6f46672e7eae970f6807eed).

If you know of a better fix or if i'm doing something here that isn't quite right let me know and i'll fix and test.